### PR TITLE
Fixing the 'phrase' typo per #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ print(level) -- 2
 -- concatenate strings
 local phrase = "My name is "
 local name = "John Doe"
-print(phase .. name) --My name is John Doe
+print(phrase .. name) --My name is John Doe
 
 -- strings and numbers
 local age = 12


### PR DESCRIPTION
I see you're active in GitHub so it's weird this repo has largely been abandoned despite a great video. 

Anyways, here's a Pull that simply fixes #5